### PR TITLE
Add support for arrow functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -368,6 +368,19 @@ def('call', function(callee, args){
   };
 });
 
+def(['arrow'], function(args, body){
+  var loc = this.loc;
+  return {
+    type: 'ArrowFunctionExpression',
+    params: args.map(function(arg){
+      return typeof arg === 'string'
+        ? e.id(arg, loc)
+        : arg;
+    }),
+    body: e.block(body, loc)
+  };
+});
+
 docsSection('property access');
 
 def('.', function(obj, prop){

--- a/tests.js
+++ b/tests.js
@@ -86,6 +86,10 @@ test('basics', function(t){
     'a > 0 ? undefined : undefined'
   );
 
+  tt(e.arrow(['a', 'b'], [
+    e('return', e('+', e.id('a'), e.id('b')))
+  ], 'add'), '(a, b) => {return a + b;}');
+
   tt(e('?', e('>', e.id('a'), e.num(0)),
         e.id('a')),
     'a > 0 ? a : undefined'


### PR DESCRIPTION
I've added very basic support for arrow functions. I had a look at the equivalent for functions, and offered a similar feature with `e.arrow(params, args)`

I chose not to support the final `id` argument. It would be a shortcut for users, because it would be really common to be assigning an arrow function to a var, but I chose not to as it's not strictly necessary.
 